### PR TITLE
remove the /static/ prefix

### DIFF
--- a/bundle_static
+++ b/bundle_static
@@ -14,25 +14,36 @@ else
   DEST="$HERE/build"
 fi
 
+
+# prepare the destination directory
+test -d "$DEST" || mkdir -p "$DEST"
+
+for d in colab extern ipython closure; do
+  echo "rm -rf $DEST/$d"
+  rm -rf "$DEST/$d"
+done
+
+IPYTHON_STATIC=`python -c 'import IPython.html; print(IPython.html.DEFAULT_STATIC_FILES_PATH)'`
+COLAB_RESOURCES="$HERE/colaboratory/resources"
+COLAB_STATIC="$HERE/static"
+CLOSURE="$COLAB_RESOURCES/closure-library/closure/goog"
+
 set -x
 
-# make the static directory
-STATIC="$DEST/static"
-rm -rf "$STATIC"
-mkdir -p "$STATIC"
+pushd $HERE > /dev/null
+git submodule init && git submodule update
+popd > /dev/null
+
 
 # stage the basic colab and extern directories
-COLAB_RESOURCES="$HERE/colaboratory/resources"
-cp -r "$COLAB_RESOURCES/colab/" "$STATIC/colab/"
-cp -r "$COLAB_RESOURCES/extern/" "$STATIC/extern/"
+cp -r "$COLAB_STATIC/" "$DEST/"
+cp -r "$COLAB_RESOURCES/colab/" "$DEST/colab/"
+cp -r "$COLAB_RESOURCES/extern/" "$DEST/extern/"
 
 # stage IPython's static files, then clobber them with patched versions
-IPYTHON_STATIC=`python -c 'import IPython.html; print(IPython.html.DEFAULT_STATIC_FILES_PATH)'`
-cp -r "$IPYTHON_STATIC/" "$STATIC/ipython/"
-rm -rf "$STATIC/ipython/components/.git"
-cp -r "$COLAB_RESOURCES/ipython_patch/" "$STATIC/ipython/"
+cp -r "$IPYTHON_STATIC/" "$DEST/ipython/"
+rm -rf "$DEST/ipython/components/.git"
+cp -r "$COLAB_RESOURCES/ipython_patch/" "$DEST/ipython/"
 
 # stage closure from the submodule
-git submodule init && git submodule update
-CLOSURE="$COLAB_RESOURCES/closure-library/closure/goog"
-cp -r "$CLOSURE/" "$STATIC/closure/"
+cp -r "$CLOSURE/" "$DEST/closure/"

--- a/colaboratory/colaboratory.py
+++ b/colaboratory/colaboratory.py
@@ -117,15 +117,6 @@ def load_handlers(name):
 #-----------------------------------------------------------------------------
 from IPython.html.base.handlers import IPythonHandler
 
-class RootHandler(IPythonHandler):
-    """Redirect a request to the corresponding tree URL"""
-
-    @web.authenticated
-    def get(self):
-        # FIXME: get rid of disk-relative paths here!
-        with open(os.path.join(here, '../static/frontend/welcome.html')) as f:
-            self.write(f.read())
-
 class ColaboratoryWebApplication(web.Application):
 
     def __init__(self, ipython_app, kernel_manager, notebook_manager,
@@ -175,14 +166,14 @@ class ColaboratoryWebApplication(web.Application):
     def init_handlers(self, settings):
         # Load the (URL pattern, handler) tuples for each component.
         here = os.path.dirname(__file__)
-        handlers = [(r'/', web.RedirectHandler, {'url':'/static/colab/welcome.html'}),
-                    (r'/static/colab/(.*)', web.StaticFileHandler,
+        handlers = [(r'/', web.RedirectHandler, {'url':'/colab/welcome.html'}),
+                    (r'/colab/(.*)', web.StaticFileHandler,
                         {'path': pjoin(RESOURCES, 'colab')}),
-                    (r'/static/extern/(.*)', web.StaticFileHandler,
+                    (r'/extern/(.*)', web.StaticFileHandler,
                         {'path': pjoin(RESOURCES, 'extern')}),
-                    (r'/static/closure/(.*)', web.StaticFileHandler,
+                    (r'/closure/(.*)', web.StaticFileHandler,
                         {'path': pjoin(RESOURCES, 'closure-library', 'closure', 'goog')}),
-                    (r'/static/ipython/(.*)', FileFindHandler,
+                    (r'/ipython/(.*)', FileFindHandler,
                         {'path': [pjoin(RESOURCES, 'ipython_patch'), DEFAULT_STATIC_FILES_PATH]}),
         ]
         

--- a/colaboratory/resources/colab/js/cell/outputarea.js
+++ b/colaboratory/resources/colab/js/cell/outputarea.js
@@ -168,12 +168,12 @@ colab.cell.OutputArea.html = '<head>' +
     '   IPython.keyboard_manager = {};' +
     '   IPython.keyboard_manager.register_events = function(x) {};' +
     '</script>' +
-    '<script src="/static/ipython/components/jquery/jquery.min.js"></script>' +
-    '<script src="/static/colab/js/cell/outputframe.js"></script>' +
-    '<script src="/static/ipython/base/js/utils.js"></script>' +
-    '<script src="/static/colab/js/colabtools.js"></script>' +
-    '<script src="/static/colab/js/interactive_widgets.js"></script>' +
-    '<script src="/static/ipython/notebook/js/outputarea.js"></script>' +
+    '<script src="/ipython/components/jquery/jquery.min.js"></script>' +
+    '<script src="/colab/js/cell/outputframe.js"></script>' +
+    '<script src="/ipython/base/js/utils.js"></script>' +
+    '<script src="/colab/js/colabtools.js"></script>' +
+    '<script src="/colab/js/interactive_widgets.js"></script>' +
+    '<script src="/ipython/notebook/js/outputarea.js"></script>' +
     '<script>' +
     '    if (!window[\'colab\']) {' +
     '        window.parent.postMessage({target:\'notebook\',' +
@@ -206,7 +206,7 @@ colab.cell.OutputArea.prototype.createOutput = function() {
     // support sandbox at all, we should be serving this from a
     // different domain, otherwise it is a security hole if browser
     // ignores sandbox attribute.
-    //  src: '/static/ipython/v2/outputframe.html',
+    //  src: '/ipython/v2/outputframe.html',
     height: '20px',
     srcdoc: colab.cell.OutputArea.html,
     sandbox: 'allow-forms allow-scripts'

--- a/colaboratory/resources/colab/js/params.js
+++ b/colaboratory/resources/colab/js/params.js
@@ -65,7 +65,7 @@ colab.params.getHashParams = function() {
  */
 colab.params.getNotebookUrl = function(params) {
   // TODO(kestert): make index.html a constant in this file.
-  return '/static/colab/notebook.html#' + colab.params.encodeParamString(params);
+  return '/colab/notebook.html#' + colab.params.encodeParamString(params);
 };
 
 /**

--- a/colaboratory/resources/colab/notebook.html
+++ b/colaboratory/resources/colab/notebook.html
@@ -11,19 +11,19 @@
      <!-- Fav icon -->
     <link rel="shortcut icon" href="img/colab-black.png" />
 
-    <link rel="stylesheet" href="/static/ipython/components/codemirror/lib/codemirror.css"/>
-    <link rel="stylesheet" href="/static/ipython/components/codemirror/addon/hint/show-hint.css"/>
+    <link rel="stylesheet" href="../ipython/components/codemirror/lib/codemirror.css"/>
+    <link rel="stylesheet" href="../ipython/components/codemirror/addon/hint/show-hint.css"/>
   </head>
   <body>
 
-    <script src="/static/ipython/components/jquery/jquery.min.js"></script>
+    <script src="../ipython/components/jquery/jquery.min.js"></script>
 
     <script src="../closure/base.js"></script>
 
     <!-- Load the CodeMirror libraries. -->
-    <script src="/static/ipython/components/codemirror/lib/codemirror.js"></script>
-    <script src="/static/ipython/components/codemirror/addon/hint/show-hint.js"></script>
-    <script src="/static/ipython/components/codemirror/mode/python/python.js"></script>
+    <script src="../ipython/components/codemirror/lib/codemirror.js"></script>
+    <script src="../ipython/components/codemirror/addon/hint/show-hint.js"></script>
+    <script src="../ipython/components/codemirror/mode/python/python.js"></script>
 
     <!-- Load the notebook libraries. -->
     <script type="text/javascript">
@@ -40,12 +40,12 @@
             src="../extern/mathjax/MathJax.js?config=TeX-AMS_HTML-full&delayStartupUntil=configured"
             charset="utf-8">
     </script>
-    <script src="/static/ipython/base/js/ipython.js"></script>
-    <script src="/static/ipython/base/js/utils.js"></script>
-    <script src="/static/ipython/services/kernels/js/comm.js"></script>
-    <script src="/static/ipython/services/kernels/js/kernel.js"></script>
-    <script src="/static/ipython/services/sessions/js/session.js"></script>
-    <script src="/static/ipython/notebook/js/mathjaxutils.js"
+    <script src="../ipython/base/js/ipython.js"></script>
+    <script src="../ipython/base/js/utils.js"></script>
+    <script src="../ipython/services/kernels/js/comm.js"></script>
+    <script src="../ipython/services/kernels/js/kernel.js"></script>
+    <script src="../ipython/services/sessions/js/session.js"></script>
+    <script src="../ipython/notebook/js/mathjaxutils.js"
             type="text/javascript"
             charset="utf-8">
     </script>

--- a/install_chrome
+++ b/install_chrome
@@ -7,7 +7,7 @@ set -x
 DEST=build_chrome
 
 # stage static files
-./bundle_static $DEST
+./bundle_static $DEST/static
 
 # copy chrome app files, putting pnacl files in root
 # as the folder structure is hard coded into the pnacl kernel code

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <title>Redirecting</title>
+  <script type="text/javascript">
+  document.location="colab/welcome.html"
+  </script>
+</head>
+<body>
+  Redirecting
+</body>
+</html>


### PR DESCRIPTION
and add redirect from '/' to '/colab/welcome.html' for the static build,
matching the Python server entrypoint.

closes #30 
