### PR TITLE
use absolute URLs

### DIFF
--- a/bundle_static
+++ b/bundle_static
@@ -17,8 +17,9 @@ fi
 
 # prepare the destination directory
 test -d "$DEST" || mkdir -p "$DEST"
+mkdir -p "$DEST"
 
-for d in colab extern ipython closure; do
+for d in colab extern ipython closure welcome notebook; do
   echo "rm -rf $DEST/$d"
   rm -rf "$DEST/$d"
 done
@@ -34,9 +35,14 @@ pushd $HERE > /dev/null
 git submodule init && git submodule update
 popd > /dev/null
 
+# stage the /, /welcome/, and /notebook/ URLs
+cp -r "$COLAB_STATIC/" "$DEST/"
+for name in welcome notebook; do
+  mkdir "$DEST/$name"
+  cp "$COLAB_RESOURCES/colab/$name.html" "$DEST/$name/index.html"
+done
 
 # stage the basic colab and extern directories
-cp -r "$COLAB_STATIC/" "$DEST/"
 cp -r "$COLAB_RESOURCES/colab/" "$DEST/colab/"
 cp -r "$COLAB_RESOURCES/extern/" "$DEST/extern/"
 

--- a/colaboratory/colaboratory.py
+++ b/colaboratory/colaboratory.py
@@ -115,7 +115,12 @@ def load_handlers(name):
 #-----------------------------------------------------------------------------
 # The Tornado web application
 #-----------------------------------------------------------------------------
-from IPython.html.base.handlers import IPythonHandler
+
+class SingleStaticFileHandler(web.StaticFileHandler):
+    def get_absolute_path(self, root, path):
+        p = os.path.abspath(os.path.join(self.root, self.default_filename))
+        return p
+
 
 class ColaboratoryWebApplication(web.Application):
 
@@ -166,9 +171,14 @@ class ColaboratoryWebApplication(web.Application):
     def init_handlers(self, settings):
         # Load the (URL pattern, handler) tuples for each component.
         here = os.path.dirname(__file__)
-        handlers = [(r'/', web.RedirectHandler, {'url':'/colab/welcome.html'}),
+        colab = pjoin(RESOURCES, 'colab')
+        handlers = [(r'/', web.RedirectHandler, {'url':'/welcome'}),
+                    (r'/welcome(/?)', SingleStaticFileHandler,
+                        {'path': colab, 'default_filename': 'welcome.html'}),
+                    (r'/notebook(/?)', SingleStaticFileHandler,
+                        {'path': colab, 'default_filename': 'notebook.html'}),
                     (r'/colab/(.*)', web.StaticFileHandler,
-                        {'path': pjoin(RESOURCES, 'colab')}),
+                        {'path': colab}),
                     (r'/extern/(.*)', web.StaticFileHandler,
                         {'path': pjoin(RESOURCES, 'extern')}),
                     (r'/closure/(.*)', web.StaticFileHandler,

--- a/colaboratory/resources/colab/drive.html
+++ b/colaboratory/resources/colab/drive.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="../closure/base.js"></script>
+    <script src="/closure/base.js"></script>
 
-    <script src="js/params.js"></script>
-    <script src="js/drivehandler.js"></script>
+    <script src="/colab/js/params.js"></script>
+    <script src="/colab/js/drivehandler.js"></script>
   </head>
 </html>

--- a/colaboratory/resources/colab/js/cell/outputarea.js
+++ b/colaboratory/resources/colab/js/cell/outputarea.js
@@ -160,8 +160,8 @@ colab.cell.OutputArea.prototype.clearOutput = function() {
  * @type {string}
  */
 colab.cell.OutputArea.html = '<head>' +
-    '<link rel="stylesheet" href="css/ansi.css"/>' +
-    '<link rel="stylesheet" href="css/main.css"/>' +
+    '<link rel="stylesheet" href="/colab/css/ansi.css"/>' +
+    '<link rel="stylesheet" href="/colab/css/main.css"/>' +
     '<script>' +
     '   IPython  = {};' +
     '   IPython.namespace = function() {};' +

--- a/colaboratory/resources/colab/js/params.js
+++ b/colaboratory/resources/colab/js/params.js
@@ -65,7 +65,7 @@ colab.params.getHashParams = function() {
  */
 colab.params.getNotebookUrl = function(params) {
   // TODO(kestert): make index.html a constant in this file.
-  return '/colab/notebook.html#' + colab.params.encodeParamString(params);
+  return '/notebook#' + colab.params.encodeParamString(params);
 };
 
 /**

--- a/colaboratory/resources/colab/notebook.html
+++ b/colaboratory/resources/colab/notebook.html
@@ -9,21 +9,21 @@
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600"/>
 
      <!-- Fav icon -->
-    <link rel="shortcut icon" href="img/colab-black.png" />
+    <link rel="shortcut icon" href="/colab/img/colab-black.png" />
 
-    <link rel="stylesheet" href="../ipython/components/codemirror/lib/codemirror.css"/>
-    <link rel="stylesheet" href="../ipython/components/codemirror/addon/hint/show-hint.css"/>
+    <link rel="stylesheet" href="/ipython/components/codemirror/lib/codemirror.css"/>
+    <link rel="stylesheet" href="/ipython/components/codemirror/addon/hint/show-hint.css"/>
   </head>
   <body>
 
-    <script src="../ipython/components/jquery/jquery.min.js"></script>
+    <script src="/ipython/components/jquery/jquery.min.js"></script>
 
-    <script src="../closure/base.js"></script>
+    <script src="/closure/base.js"></script>
 
     <!-- Load the CodeMirror libraries. -->
-    <script src="../ipython/components/codemirror/lib/codemirror.js"></script>
-    <script src="../ipython/components/codemirror/addon/hint/show-hint.js"></script>
-    <script src="../ipython/components/codemirror/mode/python/python.js"></script>
+    <script src="/ipython/components/codemirror/lib/codemirror.js"></script>
+    <script src="/ipython/components/codemirror/addon/hint/show-hint.js"></script>
+    <script src="/ipython/components/codemirror/mode/python/python.js"></script>
 
     <!-- Load the notebook libraries. -->
     <script type="text/javascript">
@@ -37,79 +37,79 @@
       IPython.WidgetManager = function() {}
     </script>
     <script type="text/javascript"
-            src="../extern/mathjax/MathJax.js?config=TeX-AMS_HTML-full&delayStartupUntil=configured"
+            src="/extern/mathjax/MathJax.js?config=TeX-AMS_HTML-full&delayStartupUntil=configured"
             charset="utf-8">
     </script>
-    <script src="../ipython/base/js/ipython.js"></script>
-    <script src="../ipython/base/js/utils.js"></script>
-    <script src="../ipython/services/kernels/js/comm.js"></script>
-    <script src="../ipython/services/kernels/js/kernel.js"></script>
-    <script src="../ipython/services/sessions/js/session.js"></script>
-    <script src="../ipython/notebook/js/mathjaxutils.js"
+    <script src="/ipython/base/js/ipython.js"></script>
+    <script src="/ipython/base/js/utils.js"></script>
+    <script src="/ipython/services/kernels/js/comm.js"></script>
+    <script src="/ipython/services/kernels/js/kernel.js"></script>
+    <script src="/ipython/services/sessions/js/session.js"></script>
+    <script src="/ipython/notebook/js/mathjaxutils.js"
             type="text/javascript"
             charset="utf-8">
     </script>
 
-     <script src="js/pnacl_kernel.js"></script>
-     <script src="js/preferences.js"></script>
-     <script src="js/undo.js"></script>
-     <script src="js/dialog.js"></script>
-     <script src="js/colabdeps.js"></script>
-     <script src="js/error.js"></script>
-     <script src="js/params.js"></script>
-     <script src="js/app.js"></script>
-     <script src="js/nbformat.js"></script>
-     <script src="js/filepicker.js"></script>
-     <script src="js/permissions.js"></script>
-     <script src="js/drive.js"></script>
-     <script src="js/share.js"></script>
-     <script src="js/sharingstate.js"></script>
-     <script src="js/services.js"></script>
-     <script src="js/presence.js"></script>
-     <script src="js/cell/cell.js"></script>
-     <script src="js/cell/tooltip.js"></script>
-     <script src="js/cell/editor.js"></script>
-     <script src="js/cell/formview.js"></script>
-     <script src="js/cell/outputarea.js"></script>
-     <script src="js/cell/codecell.js"></script>
-     <script src="js/cell/textcell.js"></script>
-     <script src="js/cell/cellfactory.js"></script>
-     <script src="js/comments.js"></script>
-     <script src="js/notification.js"></script>
-     <script src="js/bottompane.js"></script>
-     <script src="js/notebook.js"></script>
-     <script src="js/header.js"></script>
-     <script src="js/main.js"></script>
+     <script src="/colab/js/pnacl_kernel.js"></script>
+     <script src="/colab/js/preferences.js"></script>
+     <script src="/colab/js/undo.js"></script>
+     <script src="/colab/js/dialog.js"></script>
+     <script src="/colab/js/colabdeps.js"></script>
+     <script src="/colab/js/error.js"></script>
+     <script src="/colab/js/params.js"></script>
+     <script src="/colab/js/app.js"></script>
+     <script src="/colab/js/nbformat.js"></script>
+     <script src="/colab/js/filepicker.js"></script>
+     <script src="/colab/js/permissions.js"></script>
+     <script src="/colab/js/drive.js"></script>
+     <script src="/colab/js/share.js"></script>
+     <script src="/colab/js/sharingstate.js"></script>
+     <script src="/colab/js/services.js"></script>
+     <script src="/colab/js/presence.js"></script>
+     <script src="/colab/js/cell/cell.js"></script>
+     <script src="/colab/js/cell/tooltip.js"></script>
+     <script src="/colab/js/cell/editor.js"></script>
+     <script src="/colab/js/cell/formview.js"></script>
+     <script src="/colab/js/cell/outputarea.js"></script>
+     <script src="/colab/js/cell/codecell.js"></script>
+     <script src="/colab/js/cell/textcell.js"></script>
+     <script src="/colab/js/cell/cellfactory.js"></script>
+     <script src="/colab/js/comments.js"></script>
+     <script src="/colab/js/notification.js"></script>
+     <script src="/colab/js/bottompane.js"></script>
+     <script src="/colab/js/notebook.js"></script>
+     <script src="/colab/js/header.js"></script>
+     <script src="/colab/js/main.js"></script>
 
     <!-- Load the Markdown libraries. -->
-    <script type="text/javascript" src="../extern/pagedown/Markdown.Converter.js"></script><style type="text/css"></style>
-    <script type="text/javascript" src="../extern/pagedown/Markdown.Sanitizer.js"></script>
-    <script type="text/javascript" src="../extern/pagedown/Markdown.Editor.js"></script>
+    <script type="text/javascript" src="/extern/pagedown/Markdown.Converter.js"></script><style type="text/css"></style>
+    <script type="text/javascript" src="/extern/pagedown/Markdown.Sanitizer.js"></script>
+    <script type="text/javascript" src="/extern/pagedown/Markdown.Editor.js"></script>
 
     <!-- Load bootstrapping code for interactive notebooks -->
-    <script src="js/colabtools.js"></script>
-    <link rel="stylesheet" href="../closure/css/common.css">
-    <link rel="stylesheet" href="../closure/css/menu.css">
-    <link rel="stylesheet" href="../closure/css/menubar.css">
-    <link rel="stylesheet" href="../closure/css/menubutton.css">
-    <link rel="stylesheet" href="../closure/css/menuitem.css">
-    <link rel="stylesheet" href="../closure/css/menuseparator.css">
-    <link rel="stylesheet" href="../closure/css/toolbar.css">
-    <link rel="stylesheet" href="../closure/css/combobox.css">
-    <link rel="stylesheet" href="../closure/css/dialog.css">
-    <link rel="stylesheet" href="css/main.css"/>
-    <link rel="stylesheet" href="css/cell.css"/>
-    <link rel="stylesheet" href="css/ansi.css"/>
-    <link rel="stylesheet" href="css/header.css"/>
-    <link rel="stylesheet" href="css/form.css"/>
-    <link rel="stylesheet" href="css/comments.css"/>
-    <link rel="stylesheet" href="css/ipython.css"/>
+    <script src="/colab/js/colabtools.js"></script>
+    <link rel="stylesheet" href="/closure/css/common.css">
+    <link rel="stylesheet" href="/closure/css/menu.css">
+    <link rel="stylesheet" href="/closure/css/menubar.css">
+    <link rel="stylesheet" href="/closure/css/menubutton.css">
+    <link rel="stylesheet" href="/closure/css/menuitem.css">
+    <link rel="stylesheet" href="/closure/css/menuseparator.css">
+    <link rel="stylesheet" href="/closure/css/toolbar.css">
+    <link rel="stylesheet" href="/closure/css/combobox.css">
+    <link rel="stylesheet" href="/closure/css/dialog.css">
+    <link rel="stylesheet" href="/colab/css/main.css"/>
+    <link rel="stylesheet" href="/colab/css/cell.css"/>
+    <link rel="stylesheet" href="/colab/css/ansi.css"/>
+    <link rel="stylesheet" href="/colab/css/header.css"/>
+    <link rel="stylesheet" href="/colab/css/form.css"/>
+    <link rel="stylesheet" href="/colab/css/comments.css"/>
+    <link rel="stylesheet" href="/colab/css/ipython.css"/>
 
     <div id="top-floater">
       <div id="header">
         <div id="header-left">
           <div id="header-logo">
-            <img src="img/colab-white.svg">
+            <img src="/colab/img/colab-white.svg">
           </div>
           <div id="header-doc-toolbar">
             <input id="doc-name" disabled>

--- a/colaboratory/resources/colab/outputframe.html
+++ b/colaboratory/resources/colab/outputframe.html
@@ -1,16 +1,16 @@
 <head>
-  <link rel="stylesheet" href="css/ansi.css"/>
-  <link rel="stylesheet" href="css/main.css"/>
+  <link rel="stylesheet" href="/colab/css/ansi.css"/>
+  <link rel="stylesheet" href="/colab/css/main.css"/>
   <script>
      IPython  = {};
      IPython.namespace = function() {};
   </script>
-  <script src="../ipython/components/jquery/jquery.min.js"></script>
-  <script src="js/cell/outputframe.js"></script>
-  <script src="../ipython/base/js/utils.js"></script>
-  <script src="../ipython/custom/colabtools.js"></script>
-  <script src="js/interactive_widgets.js"></script>
-  <script src="../ipython/notebook/js/outputarea.js"></script>
+  <script src="/ipython/components/jquery/jquery.min.js"></script>
+  <script src="/colab/js/cell/outputframe.js"></script>
+  <script src="/ipython/base/js/utils.js"></script>
+  <script src="/ipython/custom/colabtools.js"></script>
+  <script src="/colab/js/interactive_widgets.js"></script>
+  <script src="/ipython/notebook/js/outputarea.js"></script>
 </head>
 
 <body style="background: white;">

--- a/colaboratory/resources/colab/welcome.html
+++ b/colaboratory/resources/colab/welcome.html
@@ -8,27 +8,27 @@
       TODO(kayur, sandler): When this becomes a template, we could
        switch automatically based on url parameters or config.
     -->
-    <script src="../closure/base.js"></script>
+    <script src="/closure/base.js"></script>
 
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:300,600">
 
     <!-- Fav icon -->
-    <link rel="shortcut icon" href="img/colab-black.png">
+    <link rel="shortcut icon" href="/colab/img/colab-black.png">
 
-    <script src="js/params.js"></script>
-    <script src="js/filepicker.js"></script>
-    <script src="js/install.js"></script>
-    <script src="js/welcome.js"></script>
+    <script src="/colab/js/params.js"></script>
+    <script src="/colab/js/filepicker.js"></script>
+    <script src="/colab/js/install.js"></script>
+    <script src="/colab/js/welcome.js"></script>
 
-    <link rel="stylesheet" href="../closure/css/common.css">
-    <link rel="stylesheet" href="css/header.css"/>
-    <link rel="stylesheet" href="css/main.css"/>
-    <link rel="stylesheet" href="css/welcome.css"/>
+    <link rel="stylesheet" href="/closure/css/common.css">
+    <link rel="stylesheet" href="/colab/css/header.css"/>
+    <link rel="stylesheet" href="/colab/css/main.css"/>
+    <link rel="stylesheet" href="/colab/css/welcome.css"/>
   </head>
   <body>
 
 <!--     <div id="welcome-logo">
-      <img src="img/logo.png" id="logo">
+      <img src="/colab/img/logo.png" id="logo">
     </div>
  -->
     <div id="main-content">
@@ -42,7 +42,7 @@
               Analyze data using standard google3 and open source tools.
             </div>
 
-            <img src="img/library-logos.png">
+            <img src="/colab/img/library-logos.png">
           </div>
 
           <div class="subsection">

--- a/static/index.html
+++ b/static/index.html
@@ -1,11 +1,11 @@
 <html>
 <head>
-  <title>Redirecting</title>
+  <title>Redirecting to welcome</title>
   <script type="text/javascript">
-  document.location="colab/welcome.html"
+  document.location="/welcome";
   </script>
 </head>
 <body>
-  Redirecting
+  Redirecting to <a href="/welcome">welcome page</a>.
 </body>
 </html>


### PR DESCRIPTION
allows welcome and notebook to be served from '/welcome' and '/notebook' as requested in #30, as opposed to /colab/welcome.html.

This does make the code slightly less portable because it will no longer work with a URL prefix.

The bundle_static results create /(welcome|notebook)/index.html in order to behave the same way.
