### PR TITLE
Disables filepicker on old Chrome versions

### DIFF
--- a/colaboratory/resources/colab/js/app.js
+++ b/colaboratory/resources/colab/js/app.js
@@ -12,6 +12,7 @@
 
 goog.provide('colab.app');
 
+goog.require('colab.notification');
 goog.require('colab.params');
 goog.require('goog.Promise');
 
@@ -138,4 +139,31 @@ colab.app.authorize = function(immediate, opt_callback) {
       }
     }
   });
+};
+
+
+/**
+ * Minimum version of Chrome that allows for mounting local directories in
+ * PNaCl.
+ * @type {string}
+ */
+colab.app.MOUNT_LOCAL_DIRECTORY_MIN_CHROME_VERSION = '38.0.2091.2';
+
+
+/**
+ * Check the Chrome browser version is greater than or equal to the specified
+ * version, and display a warning if it is.
+ *
+ * @param {string} minVersion The minimum browser version required.
+ * @return {boolean} True if the browser version was greater than or equal to
+ *     the minimum required version.
+ */
+colab.app.checkVersionAndWarnUser = function(minVersion) {
+  if (window.navigator.appVersion.match('Chrome\/(.*?) ')[1] < minVersion) {
+    var message = ('This feature requires Chrome version ' + minVersion +
+      ' or higher.');
+    colab.notification.showPrimary(message);
+    return false;
+  }
+  return true;
 };

--- a/colaboratory/resources/colab/js/header.js
+++ b/colaboratory/resources/colab/js/header.js
@@ -36,14 +36,6 @@ goog.require('goog.ui.menuBarDecorator');
 
 
 /**
- * Minimum version of Chrome that allows for mounting local directories
- * in PNaCl.
- * @type {string}
- */
-colab.MOUNT_LOCAL_DIRECTORY_MIN_CHROME_VERSION = '38.0.2091.2';
-
-
-/**
  * Setup coLaboratory header.
  * @param {colab.drive.NotebookModel} notebook the current realtime document.
  */
@@ -159,16 +151,8 @@ colab.createMenubar = function(notebook) {
       case 'openlocalfs-menuitem':
         // Test if Chrome Versions is new enough for PNaCl to support
         // mounting local directories.
-        if (window.navigator.appVersion.match('Chrome\/(.*?) ')[1] <
-          colab.MOUNT_LOCAL_DIRECTORY_MIN_CHROME_VERSION) {
-          var text = 'Could not pick file/directory';
-          var reason = {
-            'message': ('Mounting local directories requires Chrome version ' + 
-              colab.MOUNT_LOCAL_DIRECTORY_MIN_CHROME_VERSION +
-              ' or newer.')
-          };
-          colab.dialog.displayError(text, reason);
-        } else {
+        if (colab.app.checkVersionAndWarnUser(
+          colab.app.MOUNT_LOCAL_DIRECTORY_MIN_CHROME_VERSION)) {
           colab.app.postMessage('pick_file');
         }
         break;

--- a/colaboratory/resources/colab/notebook.html
+++ b/colaboratory/resources/colab/notebook.html
@@ -65,6 +65,7 @@
      <script src="/colab/js/colabdeps.js"></script>
      <script src="/colab/js/error.js"></script>
      <script src="/colab/js/params.js"></script>
+     <script src="/colab/js/notification.js"></script>
      <script src="/colab/js/app.js"></script>
      <script src="/colab/js/pnacl_kernel.js"></script>
      <script src="/colab/js/nbformat.js"></script>
@@ -84,7 +85,6 @@
      <script src="/colab/js/cell/textcell.js"></script>
      <script src="/colab/js/cell/cellfactory.js"></script>
      <script src="/colab/js/comments.js"></script>
-     <script src="/colab/js/notification.js"></script>
      <script src="/colab/js/bottompane.js"></script>
      <script src="/colab/js/notebook.js"></script>
      <script src="/colab/js/header.js"></script>

--- a/colaboratory/resources/colab/welcome.html
+++ b/colaboratory/resources/colab/welcome.html
@@ -16,6 +16,7 @@
     <link rel="shortcut icon" href="/colab/img/colab-black.png">
 
     <script src="/colab/js/params.js"></script>
+    <script src="/colab/js/notification.js"></script>
     <script src="/colab/js/app.js"></script>
     <script src="/colab/js/filepicker.js"></script>
     <script src="/colab/js/install.js"></script>


### PR DESCRIPTION
Displays an error dialog if the user tries to mount a local directory, when the version of Chrome does not support this operation.
