### PR TITLE
Don’t use 8888 as default port

### DIFF
--- a/colaboratory/colaboratory.py
+++ b/colaboratory/colaboratory.py
@@ -254,7 +254,7 @@ class ColaboratoryApp(BaseIPythonApplication):
     def _ip_changed(self, name, old, new):
         if new == u'*': self.ip = u''
 
-    port = Integer(8888, config=True,
+    port = Integer(8844, config=True,
         help="The port the notebook server will listen on."
     )
     port_retries = Integer(50, config=True,


### PR DESCRIPTION
switch to 8844

caching redirects cause problems with other apps (IPython) on the same ports.

We should update the authorizations in the cloud consoles (add 8840-8850) before merging.
