### PR TITLE
Use weaker permissions for Drive access

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -20,7 +20,7 @@
   "oauth2": {
     "client_id": "911569945122-8t1sdq48rr7hg22tadd8amelo3tcsd3a.apps.googleusercontent.com",
     "scopes": [
-      "https://www.googleapis.com/auth/drive",
+      "https://www.googleapis.com/auth/drive.file",
       "https://www.googleapis.com/auth/drive.install"
     ]
   },

--- a/colaboratory/resources/colab/js/client_id.js
+++ b/colaboratory/resources/colab/js/client_id.js
@@ -75,7 +75,7 @@ colab.scope.FILEPICKER_SCOPE =
  * @const
  * @type {string}
  */
-colab.scope.FILE_SCOPE = 'https://www.googleapis.com/auth/drive';
+colab.scope.FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
 
 
 /**


### PR DESCRIPTION
We currently use an excessively strong OAuth scope to access Google Drive.  This commit uses a more appropriate OAuth scope, which grants access to files created or opened with this app, but not other files.
