### PR TITLE
Adds a Dockerfile for docker build of coLaboratory

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,0 @@
-A build of Jupyter coLaboratory intended to run on a server the users connect to using ssh port forwarding.
-
-The idea is that one user sets up the server, and then multiple users can connect to the same server using ssh port forwarding. On the one hand, this means all users share the same kernel. On the other hand, it avoids having to do any authentication as connecting to the server through ssh already covers this.
-
-Note that the server running this images should not expose port 8844 except through ssh port forwarding or some other authenticated connection, as there is no authentication in the IPython kernel itself.


### PR DESCRIPTION
Adds a Dockerfile to build a docker image for coLaboratory.  This image is designed to run on a server that users connect to through ssh using port forwarding.  It is not intended to act as a web server, as there is no authentication done by the kernel.
