### PR TITLE
Update requirements to use iPython version 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ipython[notebook]
+ipython[notebook]==2.4.1


### PR DESCRIPTION
Fixes the "Could not find a version that satisfies the requirement zmqrelated" error. That module no longer exists in the latest version of iPython.